### PR TITLE
IPv4 Netzmaske angepasst

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Name=eth0
 
 [Network]
 DNS=109.239.48.251
-Address=xx.xxx.xx.183/25
+Address=xx.xxx.xx.183/24
 Gateway=xx.xxx.xx.254
 
 Address=2a00:xxxx:3::cf/64


### PR DESCRIPTION
Die IPv4 Netzmaske war bei den meisten Jiffyboxen immer 255.255.255.0 also sollte die CIDR /24 sein.